### PR TITLE
fix: remove links to examples/

### DIFF
--- a/docs/api/dingAPI.md
+++ b/docs/api/dingAPI.md
@@ -62,8 +62,6 @@ export function isDingTalk() {
 ```
 :::
 
-用户可以访问官方提供的[使用钉钉JSAPI](/docs/examples/dingTalkAPI)来查看效果及具体实现。
-
 ## API列表
 
 ### 容器

--- a/docs/guide/concept/customComponent.md
+++ b/docs/guide/concept/customComponent.md
@@ -33,7 +33,7 @@ order: 11
 
 ## 导入自定义组件 Schema
 
-在示例部分，我们提供了多个[自定义组件示例](/docs/examples/customComponent/pageBottom)，开发者可以通过以下步骤将示例中的 Schema 导入到自己创建的自定义组件中并在业务中使用：
+在示例部分，我们提供了多个[自定义组件示例](https://docs.aliwork.com/docs/yida_support/wtwabe/oupunp/gdi5p8/sg47d6/zas20t)，开发者可以通过以下步骤将示例中的 Schema 导入到自己创建的自定义组件中并在业务中使用：
 
 ### 步骤 1：创建自定组件
 

--- a/src/components/LearningPath/data.ts
+++ b/src/components/LearningPath/data.ts
@@ -315,12 +315,12 @@ export default [
       path: '/docs/guide/FAQ/q2', 
       width: '25%', 
     }, {
-      title: '上传附件重命名', 
-      path: '/docs/examples/fileRename', 
+      title: '导入HAR包', 
+      path: '/docs/guide/FAQ/q3', 
       width: '25%', 
     }, {
-      title: '组织外用户查询免登提交数据',
-      path: '/docs/examples/queryPublicData',
+      title: '打通宜搭数据和三方系统数据',
+      path: '/docs/guide/FAQ/q4',
       width: '25%'
     }]
   }


### PR DESCRIPTION
原先引用示例（已被删除）的文档链接替换为帮助中心/开发者中心现存文档